### PR TITLE
reset deadline before socket read, refactor, fix linter warning

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -15,10 +15,48 @@ import (
 	"time"
 )
 
-func writeAll(w io.Writer, buf []byte) error {
+var (
+	// MaxBodySize is the maximum frame size we're willing to accept.
+	// The maximum size of a Bitcoin message is 32MiB.
+	MaxBodySize uint64 = 0x02000000
+)
+
+func connFromAddr(addr string) (net.Conn, error) {
+	re, err := regexp.Compile(`((tcp|unix|ipc)://)?([^:]+):?(\d*)`)
+	if err != nil {
+		return nil, err
+	}
+
+	submatch := re.FindStringSubmatch(addr)
+
+	if addrs, err := net.LookupIP(submatch[3]); (err == nil &&
+		len(addrs) > 0) || submatch[2] == "tcp" ||
+		net.ParseIP(submatch[3]) != nil || submatch[4] != "" {
+
+		// We have a TCP address.
+		return net.DialTimeout("tcp", strings.Replace(submatch[3], "*",
+			"", 1)+":"+submatch[4], time.Minute)
+
+	} else if _, err := os.Stat(submatch[3]); err == nil ||
+		submatch[2] == "unix" || submatch[2] == "ipc" {
+
+		// We have a  UNIX socket.
+		return net.DialTimeout("unix", submatch[3], time.Minute)
+	}
+
+	return nil, fmt.Errorf("couldn't resolve address %s", addr)
+}
+
+// Conn is a connection to a ZMQ server.
+type Conn struct {
+	conn    net.Conn
+	timeout time.Duration
+}
+
+func (c *Conn) writeAll(buf []byte) error {
 	written := 0
 	for written < len(buf) {
-		n, err := w.Write(buf[written:])
+		n, err := c.conn.Write(buf[written:])
 		if err != nil {
 			return err
 		}
@@ -27,12 +65,12 @@ func writeAll(w io.Writer, buf []byte) error {
 	return nil
 }
 
-func writeGreeting(w io.Writer) error {
+func (c *Conn) writeGreeting() error {
 	signature := []byte{0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0x7f}
 	version := []byte{3, 0}
 	mechanism := make([]byte, 20)
-	for i, c := range "NULL" {
-		mechanism[i] = byte(c)
+	for i, chr := range "NULL" {
+		mechanism[i] = byte(chr)
 	}
 	server := []byte{0}
 
@@ -45,16 +83,12 @@ func writeGreeting(w io.Writer) error {
 		greeting = append(greeting, 0)
 	}
 
-	if err := writeAll(w, greeting); err != nil {
-		return err
-	}
-
-	return nil
+	return c.writeAll(greeting)
 }
 
-func readGreeting(r io.Reader) error {
+func (c *Conn) readGreeting() error {
 	greet := make([]byte, 64)
-	if _, err := io.ReadFull(r, greet); err != nil {
+	if _, err := io.ReadFull(c.conn, greet); err != nil {
 		return err
 	}
 
@@ -74,50 +108,7 @@ func readGreeting(r io.Reader) error {
 	return nil
 }
 
-func readFrame(r io.Reader) (byte, []byte, error) {
-	var flagBuf [1]byte
-	if _, err := io.ReadFull(r, flagBuf[:1]); err != nil {
-		return 0, nil, err
-	}
-
-	flag := flagBuf[0]
-	if flag&0xf8 != 0 {
-		return 0, nil, errors.New("invalid flag")
-	}
-
-	var size uint64
-
-	if flag&2 == 2 {
-		// Long form
-		var buf [8]byte
-		if _, err := io.ReadFull(r, buf[:8]); err != nil {
-			return 0, nil, err
-		}
-		for _, b := range buf {
-			size = (size << 8) | uint64(b)
-		}
-	} else {
-		// Short form
-		var buf [1]byte
-		if _, err := io.ReadFull(r, buf[:1]); err != nil {
-			return 0, nil, err
-		}
-		size = uint64(buf[0])
-	}
-
-	if size > 1024*1024 {
-		return 0, nil, errors.New("frame too large")
-	}
-
-	buf := make([]byte, size)
-	if _, err := io.ReadFull(r, buf); err != nil {
-		return 0, nil, err
-	}
-
-	return flag, buf, nil
-}
-
-func writeFrame(w io.Writer, flag byte, buf []byte) error {
+func (c *Conn) writeFrame(flag byte, buf []byte) error {
 	if flag&0xf8 != 0 {
 		return errors.New("invalid flag")
 	}
@@ -142,13 +133,13 @@ func writeFrame(w io.Writer, flag byte, buf []byte) error {
 		header = []byte{flag, byte(len(buf))}
 	}
 
-	if err := writeAll(w, header); err != nil {
+	if err := c.writeAll(header); err != nil {
 		return err
 	}
-	return writeAll(w, buf)
+	return c.writeAll(buf)
 }
 
-func writeCommand(w io.Writer, name string, data []byte) error {
+func (c *Conn) writeCommand(name string, data []byte) error {
 	size := len(name)
 	if size > 255 {
 		return errors.New("command name is too long")
@@ -156,11 +147,40 @@ func writeCommand(w io.Writer, name string, data []byte) error {
 	body := append([]byte{byte(size)}, []byte(name)...)
 	buf := append(body, data...)
 	var flag byte = 4
-	return writeFrame(w, flag, buf)
+	return c.writeFrame(flag, buf)
 }
 
-func readCommand(r io.Reader) (string, []byte, error) {
-	flag, buf, err := readFrame(r)
+func (c *Conn) writeReady(socketType string) error {
+	if len(socketType) > 255 {
+		return errors.New("socket type too long")
+	}
+	const socketTypeName = "Socket-Type"
+	metadata := []byte{byte(len(socketTypeName))}
+	metadata = append(metadata, []byte(socketTypeName)...)
+	metadata = append(metadata, []byte{0, 0, 0, byte(len(socketType))}...)
+	metadata = append(metadata, []byte(socketType)...)
+	return c.writeCommand(commandReady, metadata)
+}
+
+func (c *Conn) writeMessage(parts [][]byte) error {
+	if len(parts) == 0 {
+		return errors.New("empty message")
+	}
+	for _, msg := range parts[:len(parts)-1] {
+		if err := c.writeFrame(1, msg); err != nil {
+			return err
+		}
+	}
+	return c.writeFrame(0, parts[len(parts)-1])
+}
+
+func (c *Conn) subscribe(prefix string) error {
+	msg := append([]byte{1}, []byte(prefix)...)
+	return c.writeMessage([][]byte{msg})
+}
+
+func (c *Conn) readCommand() (string, []byte, error) {
+	flag, buf, err := c.readFrame()
 	if err != nil {
 		return "", nil, err
 	}
@@ -182,8 +202,8 @@ func readCommand(r io.Reader) (string, []byte, error) {
 
 const commandReady = "READY"
 
-func readReady(r io.Reader) error {
-	name, metadata, err := readCommand(r)
+func (c *Conn) readReady() error {
+	name, metadata, err := c.readCommand()
 	if err != nil {
 		return err
 	}
@@ -222,34 +242,61 @@ func readReady(r io.Reader) error {
 	return nil
 }
 
-func writeReady(w io.Writer, socketType string) error {
-	if len(socketType) > 255 {
-		return errors.New("socket type too long")
+// Read a frame from the socket, setting deadline before each read to prevent
+// timeouts during or between frames.
+func (c *Conn) readFrame() (byte, []byte, error) {
+	var flagBuf [1]byte
+	c.conn.SetReadDeadline(time.Now().Add(c.timeout))
+	if _, err := io.ReadFull(c.conn, flagBuf[:1]); err != nil {
+		return 0, nil, err
 	}
-	const socketTypeName = "Socket-Type"
-	metadata := []byte{byte(len(socketTypeName))}
-	metadata = append(metadata, []byte(socketTypeName)...)
-	metadata = append(metadata, []byte{0, 0, 0, byte(len(socketType))}...)
-	metadata = append(metadata, []byte(socketType)...)
-	return writeCommand(w, commandReady, metadata)
-}
 
-func writeMessage(w io.Writer, parts [][]byte) error {
-	if len(parts) == 0 {
-		return errors.New("empty message")
+	flag := flagBuf[0]
+	if flag&0xf8 != 0 {
+		return 0, nil, errors.New("invalid flag")
 	}
-	for _, msg := range parts[:len(parts)-1] {
-		if err := writeFrame(w, 1, msg); err != nil {
-			return err
+
+	var size uint64
+
+	if flag&2 == 2 {
+		// Long form
+		var buf [8]byte
+		c.conn.SetReadDeadline(time.Now().Add(c.timeout))
+		if _, err := io.ReadFull(c.conn, buf[:8]); err != nil {
+			return 0, nil, err
 		}
+		for _, b := range buf {
+			size = (size << 8) | uint64(b)
+		}
+	} else {
+		// Short form
+		var buf [1]byte
+		c.conn.SetReadDeadline(time.Now().Add(c.timeout))
+		if _, err := io.ReadFull(c.conn, buf[:1]); err != nil {
+			return 0, nil, err
+		}
+		size = uint64(buf[0])
 	}
-	return writeFrame(w, 0, parts[len(parts)-1])
+
+	if size > MaxBodySize {
+		return 0, nil, errors.New("frame too large")
+	}
+
+	buf := make([]byte, size)
+	// Prevent timeout during large data read in case of slow connection.
+	c.conn.SetReadDeadline(time.Time{})
+	if _, err := io.ReadFull(c.conn, buf); err != nil {
+		return 0, nil, err
+	}
+
+	return flag, buf, nil
 }
 
-func readMessage(r io.Reader) ([][]byte, error) {
+// Read a message from the socket.
+func (c *Conn) readMessage() ([][]byte, error) {
 	var parts [][]byte
 	for {
-		flag, buf, err := readFrame(r)
+		flag, buf, err := c.readFrame()
 		if err != nil {
 			return nil, err
 		}
@@ -270,43 +317,6 @@ func readMessage(r io.Reader) ([][]byte, error) {
 	return parts, nil
 }
 
-func subscribe(w io.Writer, prefix string) error {
-	msg := append([]byte{1}, []byte(prefix)...)
-	return writeMessage(w, [][]byte{msg})
-}
-
-func connFromAddr(addr string) (net.Conn, error) {
-	re, err := regexp.Compile(`((tcp|unix|ipc)://)?([^:]+):?(\d*)`)
-	if err != nil {
-		return nil, err
-	}
-
-	submatch := re.FindStringSubmatch(addr)
-
-	if addrs, err := net.LookupIP(submatch[3]); (err == nil &&
-		len(addrs) > 0) || submatch[2] == "tcp" ||
-		net.ParseIP(submatch[3]) != nil || submatch[4] != "" {
-
-		// We have a TCP address.
-		return net.DialTimeout("tcp", strings.Replace(submatch[3], "*",
-			"", 1)+":"+submatch[4], time.Minute)
-
-	} else if _, err := os.Stat(submatch[3]); err == nil ||
-		submatch[2] == "unix" || submatch[2] == "ipc" {
-
-		// We have a  UNIX socket.
-		return net.DialTimeout("unix", submatch[3], time.Minute)
-	}
-
-	return nil, fmt.Errorf("couldn't resolve address %s", addr)
-}
-
-// Conn is a connection to a ZMQ server.
-type Conn struct {
-	conn    net.Conn
-	timeout time.Duration
-}
-
 // Subscribe connects to a publisher server and subscribes to the given topics.
 func Subscribe(addr string, topics []string, timeout time.Duration) (*Conn, error) {
 	conn, err := connFromAddr(addr)
@@ -316,26 +326,29 @@ func Subscribe(addr string, topics []string, timeout time.Duration) (*Conn, erro
 
 	conn.SetDeadline(time.Now().Add(10 * time.Second))
 
-	if err := writeGreeting(conn); err != nil {
+	c := &Conn{conn, timeout}
+
+	if err := c.writeGreeting(); err != nil {
 		conn.Close()
 		return nil, err
 	}
-	if err := readGreeting(conn); err != nil {
+	if err := c.readGreeting(); err != nil {
 		conn.Close()
 		return nil, err
 	}
 
-	if err := writeReady(conn, "SUB"); err != nil {
+	if err := c.writeReady("SUB"); err != nil {
 		conn.Close()
 		return nil, err
 	}
-	if err := readReady(conn); err != nil {
+
+	if err := c.readReady(); err != nil {
 		conn.Close()
 		return nil, err
 	}
 
 	for _, topic := range topics {
-		if err := subscribe(conn, topic); err != nil {
+		if err := c.subscribe(topic); err != nil {
 			conn.Close()
 			return nil, err
 		}
@@ -343,14 +356,13 @@ func Subscribe(addr string, topics []string, timeout time.Duration) (*Conn, erro
 
 	conn.SetDeadline(time.Time{})
 
-	return &Conn{conn, timeout}, nil
+	return c, nil
 }
 
 // Receive a message from the publisher. It blocks until a new message is
 // received.
 func (c *Conn) Receive() ([][]byte, error) {
-	c.conn.SetReadDeadline(time.Now().Add(c.timeout))
-	return readMessage(c.conn)
+	return c.readMessage()
 }
 
 // Close the underlying connection. Any further operations will fail.


### PR DESCRIPTION
This PR should fix the issue reported in https://twitter.com/siroosghanavati/status/953107436575092736 where a `readMessage` times out between `readFrame` calls and throws off alignment of future frames. It does the following:

* Fixes a linter warning by directly returning an `error` result instead of checking it for nilness.
* Refactors all of the functions except one helper to make them methods of the `Conn` object, thus giving them access to the timeout and the underlying `net.Conn` object to be able to use `SetDeadline`.
* Sets a new deadline before each socket read in `readFrame()`, preventing timeouts between and during frame reads.
* Makes the maximum frame body size an exported, package-level variable as the previously set body size was only 1 MiB, Bitcoin blocks can be 4MB, and max body size is 2^63-1 as defined by ZMTP RFC (https://rfc.zeromq.org/spec:23/ZMTP/). The default is set to 32MiB, the maximum Bitcoin message size.