### PR TITLE
zmq: prevent unnecessary timeouts and return EOF on connection termination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/lightninglabs/gozmq
+
+go 1.12

--- a/zmq.go
+++ b/zmq.go
@@ -455,3 +455,8 @@ func (c *Conn) Close() error {
 	})
 	return err
 }
+
+// RemoteAddr returns the remote network address.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}


### PR DESCRIPTION
In this PR, we address an issue where it's possible for us to time out connections when there aren't any messages to read. To address this, we'll only set read deadlines on the underlying connection when reading messages of multiple frames after the first frame has been read. This is done to ensure we receive all of the frames of a message within a reasonable time frame. When reading the first frame, we want to avoid setting them as we don't know when a new message will be available for us to read, causing us to block until its delivery. As a result, a separate issue was discovered where connections would attempt to be re-established even when the user of the connection had explicitly terminated it.