### PR TITLE
zmq: allow Receive to accept pre-allocated buffers for messages

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -16,7 +16,7 @@ func main() {
 	}
 
 	for {
-		msg, err := c.Receive()
+		msg, err := c.Receive(nil)
 		if err != nil {
 			switch e := err.(type) {
 			case net.Error:


### PR DESCRIPTION
Doing so gives users of this library more control over buffer allocations required for reading ZMQ messages. If none are provided, then the previous behavior is maintained where appropriately sized buffers are allocated for each ZMQ message frame. If buffers are provided, then they must be of adequate length to successfully read a message.